### PR TITLE
Add GCF to Agentic > Token-Efficient Formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Serialization formats and protocols designed for LLM agents, tool calling, token
 
 Formats optimized to minimize token consumption when passing structured data to LLMs.
 
+- [GCF](https://github.com/blackwell-systems/gcf) - Graph Compact Format. Universal pivot for structured data achieving 61–71% token savings across JSON, YAML, TOML, CSV, and MessagePack. 100% LLM comprehension on every frontier model (1,700+ evaluations). 33 billion+ lossless round-trips verified. Native graph syntax, session deduplication. Six implementations. Textual.
 - [TOON](https://github.com/toon-format/toon) - Token-Oriented Object Notation. Compact, schema-aware JSON alternative achieving 30–60% token savings for LLM prompts. Textual.
 - [Markdown](https://daringfireball.net/projects/markdown/) - Lightweight markup widely used as the native "language" of LLM input/output. Highly token-efficient vs HTML/XML. Textual.
 - [YAML](https://yaml.org) - Indentation-based format often more token-efficient than JSON for LLM contexts due to lack of braces/quotes. Textual.


### PR DESCRIPTION
Adds [GCF (Graph Compact Format)](https://github.com/blackwell-systems/gcf) to the Token-Efficient Formats section alongside TOON, Markdown, and YAML.

GCF is a token-optimized wire format for LLM interactions with dual encoding profiles, six language implementations, and a bidirectional MCP proxy.

Key data points:
- 71% fewer tokens than JSON, 25% fewer than TOON (15-dataset benchmark)
- 100% LLM comprehension accuracy on complex payloads across 10+ models from 3 providers
- LLMs generate valid GCF on every frontier model with a 50-token primer
- Over one billion fuzz iterations prove perfect lossless round-trip with JSON
- Six implementations: Go, TypeScript, Python, Rust, Swift, Kotlin
- Formal spec (v3.0), 156 conformance fixtures
- Bidirectional MCP proxy with session dedup (92% savings by 5th call)

Spec: https://gcformat.com
Whitepaper: DOI 10.5281/zenodo.20579817